### PR TITLE
add new debug decisions for prosperity and society currency

### DIFF
--- a/Debug/common/scripted_effects/debug_scripted_effects.txt
+++ b/Debug/common/scripted_effects/debug_scripted_effects.txt
@@ -1,0 +1,59 @@
+decrease_prosperity_effect = {
+	### Depopulated Provinces
+	if = {
+		limit = { has_province_modifier = depopulated_2	}
+		hidden_tooltip = { remove_province_modifier = depopulated_2 }
+		add_province_modifier = { name = depopulated_3 duration = -1 }
+		hidden_tooltip = {
+			clr_province_flag = recent_depopulation_2
+			set_province_flag = recent_depopulation_3
+		}
+	}
+	if = {
+		limit = { has_province_modifier = depopulated_1 }
+		hidden_tooltip = { remove_province_modifier = depopulated_1 }
+		add_province_modifier = { name = depopulated_2 duration = -1 }
+		hidden_tooltip = {
+			clr_province_flag = recent_depopulation_1
+			set_province_flag = recent_depopulation_2
+		}
+	}
+
+	### Unmodified Province
+	if = {
+		limit = {
+			NOR = {
+				has_province_modifier = prosperity_modifier_3
+				has_province_modifier = prosperity_modifier_2
+				has_province_modifier = prosperity_modifier_1
+				has_province_modifier = depopulated_1
+				has_province_modifier = depopulated_2
+				has_province_modifier = depopulated_3
+			}
+		}
+		add_province_modifier = { name = depopulated_1 duration = -1 }
+		set_province_flag = recent_depopulation_1
+	}
+
+	### Prosperous Provinces
+	if = {
+		limit = { has_province_modifier = prosperity_modifier_1 }
+		
+		remove_province_modifier = prosperity_modifier_1
+		hidden_tooltip = { set_variable = { which = prosperity_value value = 0 } }
+	}
+	if = {
+		limit = { has_province_modifier = prosperity_modifier_2	}
+
+		hidden_tooltip = { remove_province_modifier = prosperity_modifier_2 }
+		add_province_modifier = { name = prosperity_modifier_1 duration = -1 }
+		hidden_tooltip = { set_variable = { which = prosperity_value value = 100 } }
+	}
+	if = {
+		limit = { has_province_modifier = prosperity_modifier_3 }
+
+		hidden_tooltip = { remove_province_modifier = prosperity_modifier_3 }
+		add_province_modifier = { name = prosperity_modifier_2 duration = -1 }
+		hidden_tooltip = { set_variable = { which = prosperity_value value = 250 } }
+	}
+}

--- a/Debug/common/scripted_triggers/debug_scripted_triggers.txt
+++ b/Debug/common/scripted_triggers/debug_scripted_triggers.txt
@@ -1,0 +1,15 @@
+is_prosperous_trigger = {
+	OR = {
+		has_province_modifier = prosperity_modifier_1
+		has_province_modifier = prosperity_modifier_2
+		has_province_modifier = prosperity_modifier_3
+	}
+}
+
+is_depopulated_trigger = {
+	OR = {
+		has_province_modifier = depopulated_1
+		has_province_modifier = depopulated_2
+		has_province_modifier = depopulated_3
+	}	
+}

--- a/Debug/decisions/debug_decisions.txt
+++ b/Debug/decisions/debug_decisions.txt
@@ -255,4 +255,79 @@ decisions = {
 			factor = 0
 		}
 	}
+
+	debug_gain_society_currency_trivial = {
+		potential = {
+			ai = no
+		}
+		allow = {
+			is_in_society = yes
+		}
+		effect = {
+			add_society_currency_trivial_effect = yes
+		}
+		ai_will_do = {
+			factor = 0
+		}
+	}
+
+	debug_gain_society_currency_minor = {
+		potential = {
+			ai = no
+		}
+		allow = {
+			is_in_society = yes
+		}
+		effect = {
+			add_society_currency_minor_effect = yes
+		}
+		ai_will_do = {
+			factor = 0
+		}
+	}
+
+	debug_gain_society_currency_medium = {
+		potential = {
+			ai = no
+		}
+		allow = {
+			is_in_society = yes
+		}
+		effect = {
+			add_society_currency_medium_effect = yes
+		}
+		ai_will_do = {
+			factor = 0
+		}
+	}
+
+	debug_gain_society_currency_major = {
+		potential = {
+			ai = no
+		}
+		allow = {
+			is_in_society = yes
+		}
+		effect = {
+			add_society_currency_major_effect = yes
+		}
+		ai_will_do = {
+			factor = 0
+		}
+	}
+
+	debug_gain_society_currency_massive = {
+		potential = {
+			ai = no
+		}
+		allow = {
+			is_in_society = yes
+		}
+		effect = {
+			add_society_currency_massive_effect = yes
+		}
+		ai_will_do = {
+			factor = 0
+		}
+	}
 }

--- a/Debug/decisions/debug_title_decisions.txt
+++ b/Debug/decisions/debug_title_decisions.txt
@@ -187,5 +187,73 @@ title_decisions = {
 		ai_will_do = {
 			factor = 0
 		}
-	}	
+	}
+
+	make_prosperous = {
+		ai_target_filter = owned
+		filter = owned
+		
+		from_potential = {
+			has_global_flag = ancrel_debug
+		}
+		
+		potential = {
+			location = {
+				NOT = { has_province_modifier = prosperity_modifier_3 }
+			}
+		}
+		
+		allow = { }
+		
+		effect = {
+			location = {
+				if = {
+					limit = {
+						is_depopulated_trigger = yes
+					}
+					decrease_depopulation_effect = yes
+				}
+				if = {
+					limit = {
+						OR = {
+							is_prosperous_trigger = yes
+							is_depopulated_trigger = no
+						}
+					}
+					increase_prosperity_effect = yes
+				}
+			}
+		}
+		
+		ai_will_do = {
+			factor = 0 # debug only!
+		}
+	}
+
+	depopulate = {
+		ai_target_filter = owned
+		filter = owned
+		
+		from_potential = {
+			has_global_flag = ancrel_debug
+		}
+		
+		potential = {
+			location = {
+				NOT = {
+					has_province_modifier = depopulated_3
+				}
+			}
+		}
+		
+		allow = { }
+		
+		effect = {
+			location = { decrease_prosperity_effect = yes}
+		}
+		
+		ai_will_do = {
+			factor = 0 # debug only!
+		}
+	}
 }


### PR DESCRIPTION
This PR adds a couple of simple title decisions to add or remove prosperity from a county, including into/from "negative prosperity" (depopulation).

It also adds decisions to add society currency at increments from the vanilla scripted effects.